### PR TITLE
Added support for proxying to wrapped view.

### DIFF
--- a/Source/UINibWrapper.m
+++ b/Source/UINibWrapper.m
@@ -60,6 +60,23 @@
     return self.subviews.firstObject;
 }
 
+#pragma mark - Proxying
+
+- (id)forwardingTargetForSelector:(SEL)aSelector{
+  if([self.contentView respondsToSelector:aSelector]){
+    return self.contentView;
+  }
+  return nil;
+}
+
+- (id)valueForUndefinedKey:(NSString *)key{
+  return [self.contentView valueForKey:key];
+}
+
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key{
+  [self.contentView setValue:value forKey:key];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
These proxying methods allow for a much cleaner workflow, you can attach a `UINibWrapper` to an IBOutlet representing an instance of `YourView`, and access it as if it were a `YourView` instance.
